### PR TITLE
Compiles on Stock Release 1.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
+# Cargo-related build components
 /target
 /Cargo.lock
+
+# Emacs files
+*~
+\#*\#
+
+# Mac stuff
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ authors = ["Jared Roesch <roeschinc@gmail.com>"]
 [dependencies]
 rustc-serialize = "*"
 docopt = "*"
-docopt_macros = "*"
 toml = "*"
 csv = "*"
 threadpool = "*"

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -1,0 +1,20 @@
+use std::path::{Path, PathBuf};
+use std::fs::metadata;
+
+pub trait IsDir {
+    fn is_dir(&self) -> bool;
+}
+
+impl IsDir for Path {
+    fn is_dir(&self) -> bool {
+        metadata(self)
+            .map(|s| s.is_dir())
+            .unwrap_or(false)
+    }
+}
+
+impl IsDir for PathBuf {
+    fn is_dir(&self) -> bool {
+        self.as_path().is_dir()
+    }
+}

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -1,5 +1,5 @@
-use std::path::{Path, PathBuf};
 use std::fs::metadata;
+use std::path::{Path, PathBuf};
 
 pub trait IsDir {
     fn is_dir(&self) -> bool;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,23 +9,21 @@ extern crate threadpool;
 extern crate toml;
 
 mod dir;
-use dir::IsDir;
 
-use std::io;
-use std::io::Read;
+use std::collections::HashMap;
 use std::env::{set_current_dir, current_dir, args};
 use std::fs::{read_dir, OpenOptions};
+use std::io;
+use std::io::{BufRead, BufReader, Cursor, Error, ErrorKind, Read};
+use std::path::{Path, PathBuf};
 use std::process;
 use std::process::Command;
-use std::io::{Error, ErrorKind};
 use std::sync::mpsc::channel;
-use threadpool::ThreadPool;
-use std::io::BufReader;
-use std::io::BufRead;
-use std::io::Cursor;
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+
 use docopt::Docopt;
+use threadpool::ThreadPool;
+
+use dir::IsDir;
 
 const USAGE: &'static str = "
 Usage: grade [-n NUM] [-t TEMPLATE] <material-path> <command>

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,7 @@
-//#![feature(plugin)]
-//#![plugin(docopt_macros)]
-//#![feature(core)]
-//#![feature(path_ext)]
-
 #[macro_use]
+
 extern crate log;
 extern crate env_logger;
-//extern crate core;
 extern crate csv;
 extern crate rustc_serialize;
 extern crate docopt;
@@ -22,9 +17,7 @@ use std::env::{set_current_dir, current_dir, args};
 use std::fs::{read_dir, OpenOptions};
 use std::process;
 use std::process::Command;
-//use std::fs::PathExt;
 use std::io::{Error, ErrorKind};
-//use core::slice::SliceExt;
 use std::sync::mpsc::channel;
 use threadpool::ThreadPool;
 use std::io::BufReader;
@@ -52,26 +45,12 @@ struct Args {
     pub arg_command: String
 }
 
-// docopt!(Args derive Debug Clone, "
-// Usage: grade [-n NUM] [-t TEMPLATE] <material-path> <command>
-//        grade --help
-
-// Options:
-//   -h, --help       Show this message.
-//   -n COUNT         Truncate the output to LINE_COUNT
-//   -t TEMPLATE      Use a CSV template file
-// ", flag_n: Option<usize>, flag_t: Option<String>);
-
 fn main() {
     env_logger::init().unwrap();
 
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.decode())
         .unwrap_or_else(|e| e.exit());
-
-    // let args: Args = Args::docopt()
-    //     .decode()
-    //     .unwrap_or_else(|e| e.exit());
 
     match Grader::new(args).run() {
         Err(e) => println!("{}", e),


### PR DESCRIPTION
The framework currently only builds on a nightly `rustc` build, as it uses [`docopt_macros`](https://github.com/docopt/docopt.rs), along with some unstable components (like [`std::fs::PathExt`](https://doc.rust-lang.org/std/fs/trait.PathExt.html)).  This pull request removes dependencies for these components without adding a whole lot more code.
